### PR TITLE
Added a function for extracting decoding results to python

### DIFF
--- a/brainstorm/tools.py
+++ b/brainstorm/tools.py
@@ -133,6 +133,27 @@ def extract_and_save(network, iter, buffer_names, file_name):
                     ds[num].resize(size=num_items, axis=1)
                     ds[num][:, num_items - data.shape[1]:num_items, ...] = data
 
+def extract(network, iter, buffer_names):
+    """Apply the network to some data and return the requested buffers.
+       Batches are returned as a list and as they are provided by the data 
+       iterator, i.e. if you want results per-batch (per sequence), use an 
+       online iterator / minibatch iterator with a minibatch size of 1."""
+    iterator = iter(handler=network.handler)
+    if isinstance(buffer_names, six.string_types):
+        buffer_names = [buffer_names]
+    num_items = 0
+    ds = []
+    
+    returnData = []
+    for _ in run_network(network, iterator, all_inputs=False):
+        network.forward_pass()
+        returnBuffers = []
+        for buffer_name in buffer_names:
+            data = network.get(buffer_name)
+            returnBuffers.append(data)
+        returnData.append(returnBuffers)
+    
+    return returnData
 
 def get_in_out_layers(task_type, in_shape, out_shape, data_name='default',
                       targets_name='targets', projection_name=None,


### PR DESCRIPTION
I am unsure if I am just missing something, but I could not find a simple method for doing a forward pass on some data and then extracting the results back to python. This is a function that does this, though I am not sure that I am entirely happy with how it returns data (as a list of lists of outputs of batches).

(If I did indeed miss the easy way to do this, my suggestion would be that one of the examples should do just that - i.e. say decode some MNIST test data and display prediction vs reference)