### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ Here are some quick instructions for installing the latest master branch on Ubun
 
 ```bash
 # Install pre-requisites
-sudo apt-get install python-dev libhdf5-dev
+sudo apt-get update
+sudo apt-get install python-dev libhdf5-dev git python-pip
 # Get brainstorm
-git clone git@github.com:IDSIA/brainstorm.git
+git clone https://github.com/IDSIA/brainstorm
 # Install
 cd brainstorm
-pip install -r requirements.txt
-python setup.py install
+sudo pip install -r requirements.txt
+sudo python setup.py install
 # Build local documentation (optional)
+sudo apt-get install python-sphinx
 make docs
 ```
 To use your CUDA installation with brainstorm:


### PR DESCRIPTION
I tried to install brainstorm on a fresh Ubuntu-instance, and some steps failed. I've updated the installation steps according to what worked for me.