### PR TITLE
Clockwork layer update

### DIFF
--- a/brainstorm/layers/clockwork_layer.py
+++ b/brainstorm/layers/clockwork_layer.py
@@ -10,17 +10,16 @@ from brainstorm.structure.buffer_structure import BufferStructure, \
     StructureTemplate
 
 
-def Clockwork(size, timing, activation='tanh', name=None):
+def Clockwork(size, activation='tanh', name=None):
     return ConstructionWrapper.create(ClockworkLayerImpl,
                                       size=size,
-                                      timing=timing,
                                       name=name,
                                       activation=activation)
 
 
 class ClockworkLayerImpl(Layer):
     expected_inputs = {'default': StructureTemplate('T', 'B', '...')}
-    expected_kwargs = {'size', 'timing', 'activation'}
+    expected_kwargs = {'size', 'activation'}
 
     computes_no_gradients_for = ['timing']
 


### PR DESCRIPTION
Removed unnecessary argument 'timing' from layer. Array 'timing' should always be initialized from initializer.