### PR TITLE
decrease by rate scheduling plan

### DIFF
--- a/brainstorm/tests/test_schedules.py
+++ b/brainstorm/tests/test_schedules.py
@@ -5,8 +5,9 @@ from __future__ import division, print_function, unicode_literals
 
 import pytest
 import six
+import numpy as np
 
-from brainstorm.training.schedules import Exponential, Linear, MultiStep
+from brainstorm.training.schedules import Exponential, Linear, MultiStep, DecreaseAfterEpoch
 
 
 def test_linear():
@@ -61,3 +62,13 @@ def test_multistep():
 
     with pytest.raises(AssertionError):
         _ = sch(0, 0, 'update', 3, None, None, None)
+
+
+def test_decrease_after_epoch():
+  sch = DecreaseAfterEpoch(initial_value=0.02, T=6)
+  epochs = range(10)
+  updates = range(10)
+
+  values = [sch(epoch, update, 'epoch', 0, None, None, None)
+              for epoch, update in six.moves.zip(epochs, updates)]
+  assert np.allclose(values, [0.02] * 6 + [0.0171428, 0.015, 0.0133333, 0.012])

--- a/brainstorm/training/schedules.py
+++ b/brainstorm/training/schedules.py
@@ -144,3 +144,31 @@ class MultiStep(Describable):
                 step_number = i - 1
                 break
         return self.values[step_number]
+
+
+class DecreaseAfterEpoch(Describable):
+    """
+    A schedule for decreasing a quantity after T epochs have passed.
+    The rate is specified by the initial value divided by the number
+    of epochs.
+
+    For example:
+    DecreaseAfterEpoch(0.05, T=25)
+    will keep the quantity constant for the first 25 epochs. Afterwards
+    the quantity changes according to 1/epoch_nr.
+    """
+
+    def __init__(self, initial_value, T):
+        """
+        Args:
+            initial_value (float):
+                Initial value of the parameter
+            T (int):
+                Number of epochs before the learning rate starts to decrease
+        """
+        self.T = T
+        self.initial_value = initial_value
+
+    def __call__(self, epoch_nr, update_nr, timescale, interval,
+                 net, stepper, logs):
+        return (self.initial_value * self.T) / np.max([epoch_nr+1, self.T])


### PR DESCRIPTION
Hi, I have added a scheduling plan which I found in "Practical Recommendations for Gradient-Based Training of Deep Architectures" by Yoshua Bengio, [Llink to paper](http://arxiv.org/abs/1206.5533v2).

It keeps the quantity constant for a given amount of epochs and then starts to decrease by 1/epoch_nr.
I have added a test case too.